### PR TITLE
Add `content.publishDate` field to the content format

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ A format must contain at least one of the following unique identifier fields:
 In addition, a format can contain the following fields:
 - `content.name`: post title or product name
 - `content.type`: type of content ('product' or 'post')
+- `content.publishDate`: publish date (ISO UTC format)
 
 Characters enclosed in square brackets followed by a question mark denote conditional separators. If the value of a field could not be obtained or is empty, the conditional separator immediately adjacent to it will be omitted from the name.
 

--- a/example.conf
+++ b/example.conf
@@ -72,6 +72,7 @@ campaign.dir.name.format =
 # In addition, a format can contain the following fields:
 # `content.name`: post title or product name
 # `content.type`: type of content ('product' or 'post')
+# `content.publishDate`: publish date (ISO UTC format)
 #
 # Characters enclosed in square brackets followed by a question mark denote
 # conditional separators. If the value of a field could not be obtained or

--- a/src/utils/FilenameFormatHelper.ts
+++ b/src/utils/FilenameFormatHelper.ts
@@ -6,6 +6,7 @@ import Formatter, { FormatFieldName, FormatFieldRules, FormatFieldValues } from 
 import URLHelper from './URLHelper.js';
 import { Attachment } from '../entities/Attachment.js';
 import { Post } from '../entities/Post.js';
+import { toISODate } from './Misc.js';
 
 type CampaignDirNameFormatFieldName =
   'creator.vanity' |
@@ -26,13 +27,15 @@ type ContentDirNameFormatFieldName =
   'content.id' |
   'content.type' |
   'content.slug' |
-  'content.name';
+  'content.name' |
+  'content.publishDate';
 
 export const CONTENT_DIR_NAME_VALIDATION_SCHEMA: FormatFieldRules<ContentDirNameFormatFieldName> = [
   { name: 'content.id', atLeastOneOf: true },
   { name: 'content.type', atLeastOneOf: false },
   { name: 'content.slug', atLeastOneOf: true },
-  { name: 'content.name', atLeastOneOf: false }
+  { name: 'content.name', atLeastOneOf: false },
+  { name: 'content.publishDate', atLeastOneOf: false }
 ];
 
 type MediaFilenameFormatFieldName =
@@ -71,7 +74,8 @@ export default class FilenameFormatHelper {
       'content.id': content.id,
       'content.type': content.type,
       'content.slug': null,
-      'content.name': null
+      'content.name': null,
+      'content.publishDate': content.publishedAt ? toISODate(content.publishedAt) : null
     };
     if (content.type === 'post') {
       const urlAnalysis = content.url ? URLHelper.analyzeURL(content.url) : null;

--- a/src/utils/Misc.ts
+++ b/src/utils/Misc.ts
@@ -25,3 +25,7 @@ export function pickDefined<T>(value1?: T, value2?: T): T | undefined;
 export function pickDefined<T>(value1?: T, value2?: T) {
   return value1 !== undefined ? value1 : value2;
 }
+
+export function toISODate(date: string): string {
+  return new Date(date).toISOString().slice(0, 10);
+}


### PR DESCRIPTION
This make the date part of the `content.publishedAt` available as field to use as content directory name format. The format of date follows ISO 8601 (YYYY-MM-DD), the timezone is always UTC.

This helps organize the directories. It can be used like this:

```
content.dir.name.format = "{content.publishDate}[ - ]?{content.id}[ - ]?{content.name}"
```