### PR TITLE
Fixed Newline Error.conf

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -378,5 +378,6 @@ include.error.stack =
 # Default: "mmm dd HH:MM:ss"
 date.time.format =
 # Default: 0
-color =     # If enabled, only viewers supporting ANSI colors will be able to
-            # display the log files properly. 
+color =    
+# If enabled, only viewers supporting ANSI colors will be able to
+# display the log files properly. 


### PR DESCRIPTION
Powershell shows error on using config file due to the comment not existing in new line.

More Info :
How to replicate issue: Windows 10 Nodejs enviroment run patreon-dl via powershell, Issue command patreon-dl -c [configLocation]

powershell Error : 
![image](https://github.com/user-attachments/assets/68861e8c-19b8-47c7-b99a-096978dc91d2)

Adding newline fixed issue, 
