### PR TITLE
Allow the .patreon-dl directory to be a subdirectory

### DIFF
--- a/src/utils/FSHelper.ts
+++ b/src/utils/FSHelper.ts
@@ -150,9 +150,25 @@ export default class FSHelper {
     };
   }
 
+  /**
+   * Check whether a path refers to a directory, or a symlink which resolves to
+   * a directory
+   */
+  private isDirectory(path: string): boolean {
+    if (!fse.existsSync(path)) {
+      return false;
+    }
+    const resolved = fse.realpathSync(path);
+    if (!fse.existsSync(resolved)) {
+      return false;
+    }
+    const stat = fse.lstatSync(resolved);
+    return stat.isDirectory();
+  }
+
   createDir(dir: string, parents = true) {
     if (fse.existsSync(dir)) {
-      if (!fse.lstatSync(dir).isDirectory()) {
+      if (!this.isDirectory(dir)) {
         throw Error(`"${dir}" exists but is not a directory`);
       }
       return dir;


### PR DESCRIPTION
I like to store my image files on my hard drive and the SQLite database on my SSD, because I/O contention makes database queries on my HDD quite slow. This commit allows the .patreon-dl directory to be a symlink, so the database can live on a different filesystem.

Tested locally and appears to function fine.