### PR TITLE
Create a simple GitHub Actions config for better PR feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Run linter
+      run: npm run lint
+    - name: Build project
+      run: npm run build


### PR DESCRIPTION
When making PRs to projects, it's nice to have a GitHub Actions setup that makes sure all necessary testing/linting/building jobs actually succeed - that way contributors won't forget to check and waste your time!

Actions status aren't showing up on this PR because there isn't any Actions configuration in _your_ repo, but you can see the results on this commit in my repo:

 - https://github.com/piperswe/patreon-dl/commit/2cf3b5824c3eb6fe94fea8d94f643491fce8b80b
 - https://github.com/piperswe/patreon-dl/actions/runs/18476448606