### PR TITLE
Add max video resolution control for YouTube downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo contains the `patreon-dl` library and its command-line tool. For GUI a
     - audio
     - attachments
     - embedded videos
-      - YouTube downloader built-in
+      - YouTube downloader built-in with **configurable max resolution**
       - Supports [external downloader](#embedded-videos--links---external-downloader)
 - Save campaign and content info 
 - Extensively configurable
@@ -266,6 +266,9 @@ Note the URL shown in the output. Open this URL in a web browser to begin viewin
 > Keep in mind that the web server is in no way secure. It is meant for local browsing and should not be exposed to outside parties!
 
 ## Changelog
+
+v3.3.2
+- Add `max.video.resolution` option to limit YouTube video downloads to a maximum resolution (see [example.conf](./example.conf))
 
 v3.3.1
 - Fix bugs affecting library usage:

--- a/example.conf
+++ b/example.conf
@@ -47,6 +47,14 @@ dry.run =
 # in the PATH.
 path.to.ffmpeg =
 
+# Maximum video resolution to download (height in pixels)
+# Applies to YouTube videos. Common values: 480, 720, 1080, 1440, 2160
+# If not set or set to 0, the best available quality will be downloaded.
+# Note: Patreon native videos (M3U8) are handled by FFmpeg and resolution
+# selection is automatic.
+# Default: not set (download best quality)
+max.video.resolution =
+
 [output]
 # Path to directory where content is saved
 # Default: current working directory

--- a/src/cli/CLIOptions.ts
+++ b/src/cli/CLIOptions.ts
@@ -86,6 +86,7 @@ export function getCLIOptions(skipTargetURLs = false): CLIOptions | Omit<CLIOpti
       infoAPI: CLIOptionValidator.validateString(pickDefined(commandLineOptions.fileExistsAction?.infoAPI, configFileOptions?.fileExistsAction?.infoAPI), 'overwrite', 'skip', 'saveAsCopy', 'saveAsCopyIfNewer')
     },
     embedDownloaders: getEmbedDownloaderOptions(configFileOptions),
+    maxVideoResolution: CLIOptionValidator.validateNumber(pickDefined(commandLineOptions.maxVideoResolution, configFileOptions?.maxVideoResolution)),
     noPrompt: CLIOptionValidator.validateBoolean(pickDefined(commandLineOptions.noPrompt, configFileOptions?.noPrompt)) || false,
     dryRun: CLIOptionValidator.validateBoolean(pickDefined(commandLineOptions.dryRun, configFileOptions?.dryRun)) || false,
     consoleLogger,

--- a/src/cli/ConfigFileParser.ts
+++ b/src/cli/ConfigFileParser.ts
@@ -9,6 +9,7 @@ const CONFIG_FILE_PROPS = {
   stopOn: 'downloader:stop.on',
   noPrompt: 'downloader:no.prompt',
   pathToFFmpeg: 'downloader:path.to.ffmpeg',
+  maxVideoResolution: 'downloader:max.video.resolution',
   dryRun: 'downloader:dry.run',
   outDir: 'output:out.dir',
   dirNameFormat: {
@@ -102,6 +103,7 @@ export default class ConfigFileParser {
       useStatusCache: __getValue(CONFIG_FILE_PROPS.useStatusCache),
       stopOn: __getValue(CONFIG_FILE_PROPS.stopOn),
       pathToFFmpeg: __getValue(CONFIG_FILE_PROPS.pathToFFmpeg),
+      maxVideoResolution: __getValue(CONFIG_FILE_PROPS.maxVideoResolution),
       outDir: __getValue(CONFIG_FILE_PROPS.outDir),
       dirNameFormat: {
         campaign: __getValue(CONFIG_FILE_PROPS.dirNameFormat.campaign),

--- a/src/downloaders/DownloaderOptions.ts
+++ b/src/downloaders/DownloaderOptions.ts
@@ -68,6 +68,7 @@ export interface DownloaderOptions {
     infoAPI?: FileExistsAction;
   };
   embedDownloaders?: EmbedDownloader[];
+  maxVideoResolution?: number | null;
   logger?: Logger | null;
   dryRun?: boolean;
 }
@@ -86,6 +87,7 @@ export type DownloaderInit = DeepRequired<Pick<DownloaderOptions,
   'embedDownloaders' |
   'dryRun'>> & {
     cookie?: string;
+    maxVideoResolution?: number | null;
   };
 
 const DEFAULT_DOWNLOADER_INIT: DownloaderInit = {
@@ -137,6 +139,7 @@ const DEFAULT_DOWNLOADER_INIT: DownloaderInit = {
     infoAPI: 'overwrite'
   },
   embedDownloaders: [],
+  maxVideoResolution: null,
   dryRun: false
 };
 
@@ -201,6 +204,7 @@ export function getDownloaderInit(options?: DownloaderOptions): DownloaderInit {
       infoAPI: options?.fileExistsAction?.infoAPI || defaults.fileExistsAction.infoAPI
     },
     embedDownloaders: pickDefined(options?.embedDownloaders, defaults.embedDownloaders),
+    maxVideoResolution: pickDefined(options?.maxVideoResolution, defaults.maxVideoResolution),
     dryRun: pickDefined(options?.dryRun, defaults.dryRun)
   };
 }
@@ -213,6 +217,7 @@ export function getDefaultDownloaderOptions(): DeepRequired<DownloaderOptions> {
   return {
     ...getDownloaderInit(),
     cookie: '',
+    maxVideoResolution: null,
     logger: null
   };
 }

--- a/src/downloaders/task/YouTubeDownloadTask.ts
+++ b/src/downloaders/task/YouTubeDownloadTask.ts
@@ -429,9 +429,13 @@ export default class YouTubeDownloadTask extends FFmpegDownloadTaskBase<YouTubeP
 
   async #pickStream(video: YT.VideoInfo): Promise<StreamBundle | null> {
     const innertube = await this.getInnertube();
+    const maxResolution = this.config.maxVideoResolution ?? null;
+
+    // First, get the best streams without filtering
     let bestVideoWithAudio: Misc.Format | null;
     let bestVideo: Misc.Format | null;
     let bestAudio: Misc.Format | null;
+
     try {
       bestVideoWithAudio = video.chooseFormat({ quality: 'best', type: 'video+audio', format: 'any' });
     }
@@ -451,6 +455,45 @@ export default class YouTubeDownloadTask extends FFmpegDownloadTaskBase<YouTubeP
     }
     catch (_error: unknown) {
       bestAudio = null;
+    }
+
+    // If max resolution is set and video exceeds it, find a lower resolution
+    if (maxResolution !== null && maxResolution > 0) {
+      const checkAndDowngrade = (format: Misc.Format | null, type: 'video+audio' | 'video'): Misc.Format | null => {
+        if (!format || !format.height) {
+          return format;
+        }
+
+        if (format.height <= maxResolution) {
+          // Current format is within limit
+          return format;
+        }
+
+        // Current format exceeds limit, find best format at or below max resolution
+        this.log('debug', `Video resolution ${format.height}p exceeds max ${maxResolution}p, finding lower resolution...`);
+
+        const availableFormats = type === 'video+audio'
+          ? (video.streaming_data?.formats || [])
+          : (video.streaming_data?.adaptive_formats || []).filter(f => f.has_video);
+
+        // Sort by height descending and find the best one at or below maxResolution
+        const suitableFormats = availableFormats
+          .filter(f => f.height && f.height <= maxResolution)
+          .sort((a, b) => (b.height || 0) - (a.height || 0));
+
+        if (suitableFormats.length > 0) {
+          this.log('debug', `Selected ${suitableFormats[0].height}p as alternative`);
+          return suitableFormats[0];
+        }
+
+        // No suitable format found, use original (better to have high res than nothing)
+        this.log('warn', `No video format found at or below ${maxResolution}p, using original ${format.height}p`);
+        return format;
+      };
+
+      bestVideoWithAudio = checkAndDowngrade(bestVideoWithAudio, 'video+audio');
+      bestVideo = checkAndDowngrade(bestVideo, 'video');
+      // Audio doesn't need downgrading
     }
 
     if (!bestVideoWithAudio && !bestVideo && !bestAudio) {


### PR DESCRIPTION
Add configurable max.video.resolution option that limits YouTube video downloads to a specified maximum resolution (height in pixels).

Key features:
- Applies to embedded YouTube videos in posts
- Common values: 480, 720, 1080, 1440, 2160
- Automatically finds best available stream at or below max resolution
- Graceful fallback if no suitable resolution available
- Works with both video+audio and video-only streams

Implementation:
- Extends DownloaderOptions with maxVideoResolution parameter
- Updates YouTubeDownloadTask to check and downgrade resolution
- Adds CLI and config file support
- Includes documentation in example.conf

This feature is useful for:
- Managing bandwidth and storage constraints
- Ensuring consistent quality across downloads
- Avoiding unnecessarily large file sizes