### PR TITLE
Escape backticks in `InnertubeLoader`

### DIFF
--- a/src/utils/yt/InnertubeLoader.ts
+++ b/src/utils/yt/InnertubeLoader.ts
@@ -153,8 +153,9 @@ export default class InnertubeLoader {
     return new Promise<any>((resolve, reject) => {
       this.log('debug', 'Begin Deno eval');
       const safeCode = code
-        .replace(/`/g, '\\`')
-        .replace(/\\/g, '\\\\');
+        .replace(/\\/g, '\\\\')
+        .replace(/\$\{/g, '\\${')
+        .replace(/`/g, '\\`');
       const wrappedCode = `
         try {
           const result = await new Function(\`${safeCode}\`)();


### PR DESCRIPTION
## Fix Deno eval parsing error

Fixes parsing errors when executing YouTube/Google JavaScript code via Deno that contains template literal syntax (`${...}`).

**Problem**: Code containing `${` sequences caused Deno parsing errors because they were interpreted as template literal interpolation when embedded in the wrapper template literal. This raised the following error:

```
Dec 07 08:38:19: error: InnertubeLoader: (stderr) Deno eval: error: The module's source code could not be parsed: Expected '}', got '{' at file://[...]/$deno$eval.mts:12:485

  ...be\\\\.com${toString{file{%3D{D{sG{1969-12-31T16:01:01.000-08:00{:{/file/index.m...
                         ~
```

**Solution**: Added escaping for `${` sequences in `#evalByDeno()` method, ensuring they're treated as literal text.

**Changes**: Updated escaping logic in `src/utils/yt/InnertubeLoader.ts` to escape `${` sequences before embedding code in template literal.

**Testing**: I tested this locally and it worked for me.