### PR TITLE
Add Streamable video downloader and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ patreon-dl --configure-youtube
 
 You can specify external programs to download embedded videos or from embedded links. For YouTube videos, this will replace the built-in downloader.
 
-See the [example config](./example-embed.conf) on how to configure an external downloader to fetch YouTube, Vimeo and SproutVideo content through [yt-dlp](https://github.com/yt-dlp/yt-dlp). Helper scripts bundled with `patreon-dl` are used in the case of Vimeo and SproutVideo ([patreon-dl-vimeo.js](./bin/patreon-dl-vimeo.js) and [patreon-dl-sprout.js](./bin/patreon-dl-sprout.js) respectively).
+See the [example config](./example-embed.conf) on how to configure an external downloader to fetch YouTube, Vimeo, SproutVideo and Streamable content through [yt-dlp](https://github.com/yt-dlp/yt-dlp). Helper scripts bundled with `patreon-dl` are used in the case of Vimeo, SproutVideo and Streamable ([patreon-dl-vimeo.js](./bin/patreon-dl-vimeo.js), [patreon-dl-sprout.js](./bin/patreon-dl-sprout.js) and [patreon-dl-streamable.js](./bin/patreon-dl-streamable.js) respectively).
 
 ## Installation
 

--- a/bin/patreon-dl-streamable.js
+++ b/bin/patreon-dl-streamable.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * External downloader for embedded Streamable videos. Obtains the appropriate URL to download from and
+ * passes it to 'yt-dlp' (https://github.com/yt-dlp/yt-dlp).
+ *
+ * Usage
+ * -----
+ * Place the following two lines in your 'patreon-dl' config file:
+ *
+ * [embed.downloader.streamable]
+ * exec = patreon-dl-streamable -o "{dest.dir}/%(title)s.%(ext)s" --embed-html "{embed.html}" --embed-url "{embed.url}"
+ *
+ * You can append the following additional options to the exec line if necessary:
+ * --video-password "<password>": for password-protected videos
+ * --yt-dlp "</path/to/yt-dlp>": if yt-dlp is not in the PATH
+ *
+ * You can pass options directly to yt-dlp. To do so, add '--' to the end of the exec line, followed by the options.
+ * For example:
+ * exec = patreon-dl-streamable -o "{dest.dir}/%(title)s.%(ext)s" --embed-html "{embed.html}" --embed-url "{embed.url}" -- --cookies-from-browser firefox
+ *
+ * Upon encountering a post with embedded Streamable content, 'patreon-dl' will call this script, which in turn proceeds to download through StreamableDownloader
+ * (see the parent class EmbedlyDownloader for more info).
+ */
+
+import EmbedlyDownloader from './EmbedlyDownloader.js';
+
+class StreamableDownloader extends EmbedlyDownloader {
+  constructor() {
+    super('Streamable', 'streamable.com');
+  }
+
+  // Override
+  getPlayerURL(html) {
+    if (html) {
+      const regex = /src="(https:\/\/streamable\.com\/e\/[^"]+)"/g;
+      const match = regex.exec(html);
+      if (match && match[1]) {
+        const url = match[1];
+        console.log("Found Streamable player URL from embed HTML:", url);
+        return url;
+      }
+      console.warn("Streamable player URL not found in embed HTML");
+    }
+    return super.getPlayerURL(html);
+  }
+}
+
+(async () => {
+  const downloader = new StreamableDownloader();
+  try {
+    process.exit(await downloader.start());
+  }
+  catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+})();

--- a/docs/Library.md
+++ b/docs/Library.md
@@ -142,7 +142,7 @@ You can specify external downloaders for embedded videos / links. Each entry in 
 
 | Proprety | Description |
 |----------|-------------|
-| `provider` | Name of the provider of embedded content. E.g. `youtube`, `vimeo` (case-insensitive) |
+| `provider` | Name of the provider of embedded content. E.g. `youtube`, `vimeo`, `streamable` (case-insensitive) |
 | `exec`  | The command to run to download the embedded content |
 
 `exec` can contain fields enclosed in curly braces. They will be replaced with actual values at runtime:

--- a/example-embed.conf
+++ b/example-embed.conf
@@ -72,3 +72,11 @@ exec = patreon-dl-vimeo -o "{dest.dir}/%(title)s.%(ext)s" --embed-html "{embed.h
 
 # See project source 'bin/patreon-dl-sprout.js' for full usage
 exec = patreon-dl-sprout -o "{dest.dir}/%(title)s.%(ext)s" --embed-html "{embed.html}" --embed-url "{embed.url}"
+
+# Example: Streamable
+# Works pretty much the same as Vimeo embed downloader.
+
+[embed.downloader.streamable]
+
+# See project source 'bin/patreon-dl-streamable.js' for full usage
+exec = patreon-dl-streamable -o "{dest.dir}/%(title)s.%(ext)s" --embed-html "{embed.html}" --embed-url "{embed.url}"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "patreon-dl": "./bin/patreon-dl.js",
     "patreon-dl-vimeo": "./bin/patreon-dl-vimeo.js",
     "patreon-dl-sprout": "./bin/patreon-dl-sprout.js",
+    "patreon-dl-streamable": "./bin/patreon-dl-streamable.js",
     "patreon-dl-server": "./bin/patreon-dl-server.js"
   },
   "author": "Patrick Kan <patrickkfkan@gmail.com> (https://github.com/patrickkfkan)",

--- a/src/entities/Post.ts
+++ b/src/entities/Post.ts
@@ -36,7 +36,7 @@ export interface Post {
    *   - only embedded link info is saved. Link is not followed / downloaded (except YouTube).
    * - video_embed
    *   - only embedded video info is saved. Video itself is not downloaded (except YouTube or
-   *     Vimeo through patreon-dl-vimeo.js).
+   *     Vimeo through patreon-dl-vimeo.js, or Streamable through patreon-dl-streamable.js).
    * - podcast
    */
   postType: string;


### PR DESCRIPTION
This pull request adds support for Streamable embeds to the project, allowing users to configure and use an external downloader for Streamable content in the same way as Vimeo and SproutVideo. The documentation, configuration examples, and code references have been updated to reflect this new capability.

Support for Streamable embeds:

* Added `patreon-dl-streamable.js` script to the `package.json` bin entries, enabling Streamable embed downloading via a helper script.
* Updated `README.md` to mention Streamable as a supported provider for external downloaders and to reference the new helper script.
* Expanded the example configuration file `example-embed.conf` to include a Streamable section, demonstrating how to use the new downloader.
* Updated `docs/Library.md` to list `streamable` as a valid provider for embedded content in the configuration documentation.
* Clarified in `src/entities/Post.ts` that Streamable embeds can now be downloaded through `patreon-dl-streamable.js`.

(PR description + title is github generated since I'm lazy)