### PR TITLE
[FEATURE] Adding support for custom urls/dns for patreon pages to patreon-dl

### DIFF
--- a/src/downloaders/Bootstrap.ts
+++ b/src/downloaders/Bootstrap.ts
@@ -47,6 +47,11 @@ export interface PostDownloaderBootstrapData extends BootstrapData {
     filters?: Record<string, any>;
     campaignId?: string;
   } | {
+    type: 'byURL';
+    url: string;
+    filters?: Record<string, any>;
+    campaignId?: string;
+  } | {
     type: 'byFile';
     filePath: string;
   };
@@ -145,6 +150,17 @@ export default class Bootstrap {
           type: 'byCollection',
           collectionId: analysis.collectionId,
           filters: analysis.filters
+        }
+      } as PostDownloaderBootstrapData;
+    }
+
+    if (analysis.type === 'customURL') {
+      return {
+        type: 'post',
+        targetURL: url,
+        postFetch: {
+          type: 'byURL',
+          url: analysis.url
         }
       } as PostDownloaderBootstrapData;
     }

--- a/src/downloaders/InitialData.ts
+++ b/src/downloaders/InitialData.ts
@@ -42,14 +42,28 @@ export class InitialData {
       this.log('debug', `Fetch initial data from "${url}"`);
       let page;
       try {
-        const { html, lastUrl } = await this.fetcher.get({ url, type: 'html', maxRetries: this.config.request.maxRetries, signal });
-        page = html;
-        if (new URL(lastUrl).pathname === '/login-sync-domains') {
-          this.log('debug', `Detected Cloudflare challenge flow at "${lastUrl}"`);
+        // For custom domains (non-patreon.com), skip the cookie-bearing fetch —
+        // sending patreon session cookies to a third-party domain can invalidate
+        // the session. Use Puppeteer directly instead.
+        const isCustomDomain = !new URL(url).hostname.endsWith('patreon.com');
+        if (isCustomDomain) {
+          this.log('debug', `Custom domain detected - using Puppeteer to avoid sending cookies to third-party domain`);
           page = await this.#fetchPageWithPuppeteer(url);
-          // Because cookie not available to Puppeteer, we need to fetch 
-          // current user ID separately
           fetchCurrentUserIdFromAPI = !!this.config.cookie;
+        }
+        else {
+          const { html, lastUrl } = await this.fetcher.get({ url, type: 'html', maxRetries: this.config.request.maxRetries, signal });
+          page = html;
+          const isCloudflareChallenge = new URL(lastUrl).pathname === '/login-sync-domains' ||
+            html.includes('window._cf_chl_opt') ||
+            html.includes('challenge-platform');
+          if (isCloudflareChallenge) {
+            this.log('debug', `Detected Cloudflare challenge flow - using Puppeteer`);
+            page = await this.#fetchPageWithPuppeteer(url);
+            // Because cookie not available to Puppeteer, we need to fetch
+            // current user ID separately
+            fetchCurrentUserIdFromAPI = !!this.config.cookie;
+          }
         }
       }
       catch (error) {

--- a/src/downloaders/InitialData.ts
+++ b/src/downloaders/InitialData.ts
@@ -45,7 +45,7 @@ export class InitialData {
         // For custom domains (non-patreon.com), skip the cookie-bearing fetch —
         // sending patreon session cookies to a third-party domain can invalidate
         // the session. Use Puppeteer directly instead.
-        const isCustomDomain = !new URL(url).hostname.endsWith('patreon.com');
+        const isCustomDomain = !URLHelper.isPatreonURL(url);
         if (isCustomDomain) {
           this.log('debug', `Custom domain detected - using Puppeteer to avoid sending cookies to third-party domain`);
           page = await this.#fetchPageWithPuppeteer(url);

--- a/src/downloaders/PostDownloader.ts
+++ b/src/downloaders/PostDownloader.ts
@@ -80,6 +80,9 @@ export default class PostDownloader extends Downloader<Post> {
       else if (postFetch.type === 'byCollection') {
         this.log('info', `Targeting posts in collection #${postFetch.collectionId}`);
       }
+      else if (postFetch.type === 'byURL') {
+        this.log('info', `Targeting posts at '${postFetch.url}'`);
+      }
       else if (postFetch.type === 'byFile') {
         this.log('info', `Target post given by API data in "${postFetch.filePath}"`);
       }
@@ -274,6 +277,9 @@ export default class PostDownloader extends Downloader<Post> {
       }
       else if (postFetch.type === 'byCollection') {
         this.log('info', `Done downloading posts in collection #${postFetch.collectionId}`);
+      }
+      else if (postFetch.type === 'byURL') {
+        this.log('info', `Done downloading posts at '${postFetch.url}'`);
       }
       else if (postFetch.type === 'byFile') {
         this.log('info', `Done downloading post given in "${postFetch.filePath}"`);
@@ -649,8 +655,8 @@ export default class PostDownloader extends Downloader<Post> {
     };
   }
 
-  #isFetchingMultiplePosts(postFetch: DownloaderConfig<Post>['postFetch']): postFetch is DownloaderConfig<Post>['postFetch'] & { type: 'byUser' | 'byUserId' | 'byCollection' } {
-    return postFetch.type === 'byUser' || postFetch.type === 'byUserId' || postFetch.type === 'byCollection';
+  #isFetchingMultiplePosts(postFetch: DownloaderConfig<Post>['postFetch']): postFetch is DownloaderConfig<Post>['postFetch'] & { type: 'byUser' | 'byUserId' | 'byCollection' | 'byURL' } {
+    return postFetch.type === 'byUser' || postFetch.type === 'byUserId' || postFetch.type === 'byCollection' || postFetch.type === 'byURL';
   }
 
   async __getCampaign(signal?: AbortSignal) {

--- a/src/downloaders/PostsFetcher.ts
+++ b/src/downloaders/PostsFetcher.ts
@@ -245,8 +245,8 @@ export default class PostsFetcher extends EventEmitter {
     this.#setStatus({ status: 'error', error });
   }
 
-  #isFetchingMultiplePosts(postFetch: DownloaderConfig<Post>['postFetch']): postFetch is DownloaderConfig<Post>['postFetch'] & { type: 'byUser' | 'byUserId' | 'byCollection' } {
-    return postFetch.type === 'byUser' || postFetch.type === 'byUserId' || postFetch.type === 'byCollection';
+  #isFetchingMultiplePosts(postFetch: DownloaderConfig<Post>['postFetch']): postFetch is DownloaderConfig<Post>['postFetch'] & { type: 'byUser' | 'byUserId' | 'byCollection' | 'byURL' } {
+    return postFetch.type === 'byUser' || postFetch.type === 'byUserId' || postFetch.type === 'byCollection' || postFetch.type === 'byURL';
   }
 
   async #getInitialPostsAPIURL() {
@@ -282,8 +282,10 @@ export default class PostsFetcher extends EventEmitter {
         return URLHelper.constructCampaignPageURL({ userId: postFetch.userId });
       case 'byCollection':
         return URLHelper.constructCollectionURL(postFetch.collectionId);
+      case 'byURL':
+        return postFetch.url;
       default:
-        throw Error(`postFetch type mismatch: expecting 'byUser', 'byUserId' or 'byCollection' but got '${postFetch.type}'`);
+        throw Error(`postFetch type mismatch: expecting 'byUser', 'byUserId', 'byCollection' or 'byURL' but got '${postFetch.type}'`);
     }
   }
 

--- a/src/parsers/PageParser.ts
+++ b/src/parsers/PageParser.ts
@@ -63,7 +63,7 @@ export default class PageParser extends Parser {
       let campaignIdMatch = campaignIdRegex.exec(html);
 
       if (!campaignIdMatch || !campaignIdMatch[1]) {
-        const campaignIdRegexSimple = /\\?\/api\/campaigns\/(\d+)/gm;
+        const campaignIdRegexSimple = /{\\"self\\":\\"https:\/\/[^"]+\/api\/campaigns\/(.+?)\\"}/gm;
         this.log('debug', `Trying fallback pattern: ${campaignIdRegexSimple}`);
         campaignIdMatch = campaignIdRegexSimple.exec(html);
       }

--- a/src/parsers/PageParser.ts
+++ b/src/parsers/PageParser.ts
@@ -60,9 +60,16 @@ export default class PageParser extends Parser {
 
       const campaignIdRegex = /{\\"self\\":\\"https:\/\/www\.patreon\.com\/api\/campaigns\/(.+?)\\"}/gm;
       this.log('debug', `Trying pattern in Next.js streaming response: ${campaignIdRegex}`);
-      const campaignIdMatch = campaignIdRegex.exec(html);
+      let campaignIdMatch = campaignIdRegex.exec(html);
+
       if (!campaignIdMatch || !campaignIdMatch[1]) {
-        throw Error(`Initial data not found - no match for pattern in Next.js streaming response: ${campaignIdRegex}`);
+        const campaignIdRegexSimple = /\\?\/api\/campaigns\/(\d+)/gm;
+        this.log('debug', `Trying fallback pattern: ${campaignIdRegexSimple}`);
+        campaignIdMatch = campaignIdRegexSimple.exec(html);
+      }
+
+      if (!campaignIdMatch || !campaignIdMatch[1]) {
+        throw Error(`Initial data not found - campaign ID not found in Next.js streaming response`);
       }
 
       const campaignId = campaignIdMatch ? campaignIdMatch[1] : undefined;

--- a/src/utils/URLHelper.ts
+++ b/src/utils/URLHelper.ts
@@ -290,6 +290,9 @@ export type URLAnalysis = {
 } | {
   type: 'shop';
   vanity: string;
+} | {
+  type: 'customURL';
+  url: string;
 }
 
 export default class URLHelper {
@@ -564,6 +567,17 @@ export default class URLHelper {
         type: 'shop',
         vanity:shopURLMatchVanity
       };
+    }
+
+    // Fallback: treat valid HTTPS URLs with non-patreon.com hostnames as custom Patreon domains
+    if (this.validateURL(base)) {
+      const urlObj = new URL(base);
+      if (urlObj.protocol === 'https:' && !urlObj.hostname.endsWith('patreon.com')) {
+        return {
+          type: 'customURL',
+          url: base
+        };
+      }
     }
 
     return null;

--- a/src/utils/URLHelper.ts
+++ b/src/utils/URLHelper.ts
@@ -570,14 +570,12 @@ export default class URLHelper {
     }
 
     // Fallback: treat valid HTTPS URLs with non-patreon.com hostnames as custom Patreon domains
-    if (this.validateURL(base)) {
-      const urlObj = new URL(base);
-      if (urlObj.protocol === 'https:' && !urlObj.hostname.endsWith('patreon.com')) {
-        return {
-          type: 'customURL',
-          url: base
-        };
-      }
+    // Note: `base` is already a valid URL (came from stripSearchParamsFromURL), no need to re-validate
+    if (!this.isPatreonURL(base)) {
+      return {
+        type: 'customURL',
+        url: base
+      };
     }
 
     return null;
@@ -595,6 +593,16 @@ export default class URLHelper {
   static getExtensionFromURL(url: string) {
     const urlObj = new URL(url);
     return path.extname(urlObj.pathname.split('/').pop() || '');
+  }
+
+  static isPatreonURL(url: string) {
+    try {
+      const { protocol, hostname } = new URL(url);
+      return protocol === 'https:' && (hostname === 'www.patreon.com' || hostname === 'patreon.com');
+    }
+    catch {
+      return false;
+    }
   }
 
   static validateURL(url: any) {


### PR DESCRIPTION
# Summary

Some patreon pages are hosted behind custom domains, for example frienji.kenjilopezalt.com. 

Currently the patreon-dl program would not work correctly when dealing with these URLs and this code update aims to add support for them. 

## Changes

- Added custom url type and support to the downloader and fetcher.  
- update url helpr to fallback to this type for custom domains

## Testing
- Was able to run against patreon pages with custom urls/dns with no issues after these updates including image, text, and video content
- Was able to do the same for a patreon page with a traditional patreon.com/* url as well

Not sure what else to test here but happy to test other aspects of this PR.

## Linting 
lints are passing 


