### PR TITLE
separated the path to the database from the path to the download output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ $ patreon-dl [OPTION]... URL
 | `--ffmpeg <path>` | `-f` | Path to FFmpeg executable |
 | `--deno <path>` | `-d` | Path to Deno executable |
 | `--out-dir <path>` |`-o` | Directory to save content |
+| `--db-dir <path>` | `-o` | Directory to save SQLite database |
 | `--log-level <level>` | `-l` | Log level of the console logger: `info`, `debug`, `warn` or `error`; set to `none` to disable the logger. |
 | `--no-prompt` | `-y` | Do not prompt for confirmation to proceed |
 | `--dry-run`   |      | Run without writing files to disk (except logs, if any). Intended for testing / debugging. |

--- a/src/browse/server/WebServer.ts
+++ b/src/browse/server/WebServer.ts
@@ -12,6 +12,7 @@ export const DEFAULT_WEB_SERVER_PORT = 3000;
 
 export interface WebServerConfig {
   dataDir?: string;
+  dbDir?: string;
   port?: number | null;
   logger?: Logger | null;
 }
@@ -42,6 +43,7 @@ export class WebServer {
     }
 
     const dataDir = this.#config.dataDir || process.cwd();
+    const dbDir = this.#config.dbDir || process.cwd();
     if (!fs.existsSync(dataDir)) {
       throw Error(`Data directory "${this.#config.dataDir}" does not exist`);
     }
@@ -49,7 +51,7 @@ export class WebServer {
       throw Error(`"${this.#config.dataDir}" is not a directory`);
     }
 
-    const dbFile = path.resolve(dataDir, '.patreon-dl', 'db.sqlite');
+    const dbFile = path.resolve(dbDir, '.patreon-dl', 'db.sqlite');
     if (!fs.existsSync(dbFile)) {
       throw Error(`DB file "${dbFile}" does not exist`);
     }

--- a/src/cli/CLIOptions.ts
+++ b/src/cli/CLIOptions.ts
@@ -76,6 +76,7 @@ export function getCLIOptions(skipTargetURLs = false): CLIOptions | Omit<CLIOpti
     pathToFFmpeg: CLIOptionValidator.validateString(pickDefined(commandLineOptions.pathToFFmpeg, configFileOptions?.pathToFFmpeg)),
     pathToDeno: CLIOptionValidator.validateString(pickDefined(commandLineOptions.pathToDeno, configFileOptions?.pathToDeno)),
     outDir: CLIOptionValidator.validateString(pickDefined(commandLineOptions.outDir, configFileOptions?.outDir)),
+    dbDir: CLIOptionValidator.validateString(pickDefined(commandLineOptions.dbDir, configFileOptions?.dbDir)),
     dirNameFormat: {
       campaign: CLIOptionValidator.validateString(pickDefined(commandLineOptions.dirNameFormat?.campaign, configFileOptions?.dirNameFormat?.campaign)),
       content: CLIOptionValidator.validateString(pickDefined(commandLineOptions.dirNameFormat?.content, configFileOptions?.dirNameFormat?.content))
@@ -104,7 +105,7 @@ export function getCLIOptions(skipTargetURLs = false): CLIOptions | Omit<CLIOpti
     fileLoggers
   } satisfies Omit<CLIOptions, 'targetURLs'>;
 
-  if (skipTargetURLs) {
+                                                                                                                                                                              if (skipTargetURLs) {
     return options;
   }
 

--- a/src/cli/CLIOptions.ts
+++ b/src/cli/CLIOptions.ts
@@ -105,7 +105,7 @@ export function getCLIOptions(skipTargetURLs = false): CLIOptions | Omit<CLIOpti
     fileLoggers
   } satisfies Omit<CLIOptions, 'targetURLs'>;
 
-                                                                                                                                                                              if (skipTargetURLs) {
+  if (skipTargetURLs) {
     return options;
   }
 

--- a/src/cli/CommandLineParser.ts
+++ b/src/cli/CommandLineParser.ts
@@ -20,6 +20,7 @@ const COMMAND_LINE_ARGS = {
   ffmpeg: 'ffmpeg',
   deno: 'deno',
   outDir: 'out-dir',
+  dbDir: 'db-dir',
   logLevel: 'log-level',
   noPrompt: 'no-prompt',
   dryRun: 'dry-run',
@@ -75,6 +76,13 @@ const OPT_DEFS = [
     name: COMMAND_LINE_ARGS.outDir,
     description: 'Path to directory where content is saved',
     alias: 'o',
+    type: String,
+    typeLabel: '<dir>'
+  },
+  {
+    name: COMMAND_LINE_ARGS.dbDir,
+    description: 'Path to directory where database is saved',
+    alias: 'D',
     type: String,
     typeLabel: '<dir>'
   },
@@ -196,6 +204,7 @@ export default class CommandLineParser {
       pathToFFmpeg: __getValue(COMMAND_LINE_ARGS.ffmpeg),
       pathToDeno: __getValue(COMMAND_LINE_ARGS.deno),
       outDir: __getValue(COMMAND_LINE_ARGS.outDir),
+      dbDir: __getValue(COMMAND_LINE_ARGS.dbDir),
       dirNameFormat: {
         campaign: undefined,
         content: undefined

--- a/src/cli/ConfigFileParser.ts
+++ b/src/cli/ConfigFileParser.ts
@@ -13,6 +13,7 @@ const CONFIG_FILE_PROPS = {
   pathToDeno: 'downloader:path.to.deno',
   dryRun: 'downloader:dry.run',
   outDir: 'output:out.dir',
+  dbDir: 'output:db.dir',
   dirNameFormat: {
     campaign: 'output:campaign.dir.name.format',
     content: 'output:content.dir.name.format'
@@ -111,6 +112,7 @@ export default class ConfigFileParser {
       maxVideoResolution: __getValue(CONFIG_FILE_PROPS.maxVideoResolution),
       pathToDeno: __getValue(CONFIG_FILE_PROPS.pathToDeno),
       outDir: __getValue(CONFIG_FILE_PROPS.outDir),
+      dbDir: __getValue(CONFIG_FILE_PROPS.dbDir),
       dirNameFormat: {
         campaign: __getValue(CONFIG_FILE_PROPS.dirNameFormat.campaign),
         content: __getValue(CONFIG_FILE_PROPS.dirNameFormat.content)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -370,6 +370,7 @@ export default class PatreonDownloaderCLI {
         delete conf.postFetch;
         delete conf.productFetch;
         delete conf.outDir;
+        delete conf.dbDir;
         const heading = 'Target URLs';
         console.log(`${EOL}${heading}`);
         console.log('-'.repeat(heading.length), EOL);
@@ -404,6 +405,7 @@ export default class PatreonDownloaderCLI {
         console.log('Abort');
         return { aborted: true, endMessage: 'Aborted' };
       }
+      console.log('Proceeding...', EOL);
       if (postConfirm) {
         postConfirm();
       }
@@ -453,18 +455,26 @@ export default class PatreonDownloaderCLI {
   }
 
   #confirmProceed(prompt?: PromptSync.Prompt): boolean {
-    if (!prompt) {
-      prompt = PromptSync({ sigint: true });
+    try {
+      if (!prompt) {
+        prompt = PromptSync({ sigint: true });
+        console.log();
+      }
+      const confirmProceed = prompt('Proceed (Y/n)? ');
+      if (!confirmProceed.trim() || confirmProceed.trim().toLowerCase() === 'y') {
+        console.log('Proceeding...', EOL);    
+        return true;
+      }
+      else if (confirmProceed.trim().toLowerCase() === 'n') {
+        return false;
+      }
+
+      return this.#confirmProceed(prompt);
     }
-    const confirmProceed = prompt('Proceed (Y/n)? ');
-    if (!confirmProceed.trim() || confirmProceed.trim().toLowerCase() === 'y') {
-      return true;
-    }
-    else if (confirmProceed.trim().toLowerCase() === 'n') {
+    catch (error) {
+      console.error('Error obtaining user input: ', error instanceof Error ? error.message : error);
       return false;
     }
-
-    return this.#confirmProceed(prompt);
   }
 
   #createLoggers(targetURL: string, options: CLIOptions) {
@@ -472,6 +482,7 @@ export default class PatreonDownloaderCLI {
     const fileLoggerInit: DownloaderFileLoggerInit = {
       targetURL,
       outDir: options.outDir,
+      dbDir: options.dbDir,
       date: new Date()
     };
     const fileLoggers = options.fileLoggers?.reduce<FileLogger[]>((result, fileLoggerOptions) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -455,26 +455,20 @@ export default class PatreonDownloaderCLI {
   }
 
   #confirmProceed(prompt?: PromptSync.Prompt): boolean {
-    try {
-      if (!prompt) {
-        prompt = PromptSync({ sigint: true });
-        console.log();
-      }
-      const confirmProceed = prompt('Proceed (Y/n)? ');
-      if (!confirmProceed.trim() || confirmProceed.trim().toLowerCase() === 'y') {
-        console.log('Proceeding...', EOL);    
-        return true;
-      }
-      else if (confirmProceed.trim().toLowerCase() === 'n') {
-        return false;
-      }
-
-      return this.#confirmProceed(prompt);
+    if (!prompt) {
+      prompt = PromptSync({ sigint: true });
+      console.log();
     }
-    catch (error) {
-      console.error('Error obtaining user input: ', error instanceof Error ? error.message : error);
+    const confirmProceed = prompt('Proceed (Y/n)? ');
+    if (!confirmProceed.trim() || confirmProceed.trim().toLowerCase() === 'y') {
+      console.log('Proceeding...', EOL);    
+      return true;
+    }
+    else if (confirmProceed.trim().toLowerCase() === 'n') {
       return false;
     }
+
+    return this.#confirmProceed(prompt);
   }
 
   #createLoggers(targetURL: string, options: CLIOptions) {
@@ -482,7 +476,6 @@ export default class PatreonDownloaderCLI {
     const fileLoggerInit: DownloaderFileLoggerInit = {
       targetURL,
       outDir: options.outDir,
-      dbDir: options.dbDir,
       date: new Date()
     };
     const fileLoggers = options.fileLoggers?.reduce<FileLogger[]>((result, fileLoggerOptions) => {

--- a/src/cli/server/ServerCLIOptions.ts
+++ b/src/cli/server/ServerCLIOptions.ts
@@ -23,6 +23,7 @@ export function getServerCLIOptions(): ServerCLIOptions {
 
   const options: ServerCLIOptions = {
     dataDir: CLIOptionValidator.validateString(commandLineOptions.dataDir),
+    dbDir: CLIOptionValidator.validateString(commandLineOptions.dbDir),
     port: CLIOptionValidator.validateNumber(commandLineOptions.port),
     consoleLogger,
     fileLogger

--- a/src/cli/server/ServerCommandLineParser.ts
+++ b/src/cli/server/ServerCommandLineParser.ts
@@ -14,6 +14,7 @@ export interface ServerCommandLineParseResult extends RecursivePropsTo<DeepParti
 const COMMAND_LINE_ARGS = {
   help: 'help',
   dataDir: 'data-dir',
+  dbDir: 'db-dir',
   port: 'port',
   logLevel: 'log-level',
   logFile: 'log-file'
@@ -30,6 +31,13 @@ const OPT_DEFS = [
     name: COMMAND_LINE_ARGS.dataDir,
     description: 'Directory containing downloaded content. Default: current working directory',
     alias: 'i',
+    type: String,
+    typeLabel: '<dir>'
+  },
+  {
+    name: COMMAND_LINE_ARGS.dbDir,
+    description: 'Directory containing the database. Default: current working directory',
+    alias: 'd',
     type: String,
     typeLabel: '<dir>'
   },
@@ -91,6 +99,7 @@ export default class ServerCommandLineParser {
 
     return {
       dataDir: __getValue(COMMAND_LINE_ARGS.dataDir),
+      dbDir: __getValue(COMMAND_LINE_ARGS.dbDir),
       port: __getValue(COMMAND_LINE_ARGS.port),
       logLevel: __getValue(COMMAND_LINE_ARGS.logLevel),
       logFile: __getValue(COMMAND_LINE_ARGS.logFile)

--- a/src/cli/server/index.ts
+++ b/src/cli/server/index.ts
@@ -51,6 +51,7 @@ export default class ServerCLI {
     try {
       server = new WebServer({
         dataDir: options.dataDir,
+        dbDir: options.dbDir,
         port: options.port,
         logger
       });

--- a/src/downloaders/DownloaderOptions.ts
+++ b/src/downloaders/DownloaderOptions.ts
@@ -65,6 +65,7 @@ export interface DownloaderOptions {
   pathToYouTubeCredentials?: string | null;
   pathToDeno?: string | null;
   outDir?: string;
+  dbDir?: string;
   dirNameFormat?: {
     campaign?: string;
     content?: string;
@@ -93,6 +94,7 @@ export interface DownloaderOptions {
 
 export type DownloaderInit = DeepRequired<Pick<DownloaderOptions,
   'outDir' |
+  'dbDir' |
   'useStatusCache' |
   'stopOn' |
   'pathToFFmpeg' |
@@ -111,6 +113,7 @@ export type DownloaderInit = DeepRequired<Pick<DownloaderOptions,
 
 const DEFAULT_DOWNLOADER_INIT: DownloaderInit = {
   outDir: process.cwd(),
+  dbDir: process.cwd(),
   useStatusCache: true,
   stopOn: 'never',
   pathToFFmpeg: null,
@@ -186,6 +189,7 @@ export function getDownloaderInit(options?: DownloaderOptions): DownloaderInit {
   return {
     cookie: options?.cookie,
     outDir: options?.outDir ? path.resolve(options.outDir) : defaults.outDir,
+    dbDir: options?.dbDir ? path.resolve(options.dbDir) : defaults.dbDir,
     useStatusCache: pickDefined(options?.useStatusCache, defaults.useStatusCache),
     stopOn: pickDefined(options?.stopOn, defaults.stopOn),
     pathToFFmpeg: pickDefined(options?.pathToFFmpeg, defaults.pathToFFmpeg),

--- a/src/utils/FSHelper.ts
+++ b/src/utils/FSHelper.ts
@@ -96,7 +96,7 @@ export default class FSHelper {
   }
 
   getDBFilePath() {
-    const dbDir = this.createDir(path.resolve(this.config.outDir, INTERNAL_DATA_DIR_NAME));
+    const dbDir = this.createDir(path.resolve(this.config.dbDir, INTERNAL_DATA_DIR_NAME));
     return path.resolve(dbDir, DB_FILENAME);
   }
 

--- a/src/utils/logging/FileLogger.ts
+++ b/src/utils/logging/FileLogger.ts
@@ -68,6 +68,7 @@ const DEFAULT_SERVER_LOGGER_FILE_EXISTS_ACTION = 'append';
 export interface DownloaderFileLoggerInit {
   targetURL: string;
   outDir?: string;
+  dbDir?: string;
   date?: Date;
 }
 

--- a/src/utils/logging/FileLogger.ts
+++ b/src/utils/logging/FileLogger.ts
@@ -68,7 +68,6 @@ const DEFAULT_SERVER_LOGGER_FILE_EXISTS_ACTION = 'append';
 export interface DownloaderFileLoggerInit {
   targetURL: string;
   outDir?: string;
-  dbDir?: string;
   date?: Date;
 }
 


### PR DESCRIPTION
Hello,

I had a use case where I needed the database to be in a separate folder from the downloaded content. In my use case, I was trying to backup the data to a Samba share which was not playing well with SQLite. To fix this, I created a new command line argument, db-dir, to specify where the database should be saved. I created a pull request because I believe that this could be a common use case for others who want to backup content to a Samba share, NAS, ZFS share or whatever else there is.