### PR TITLE
fix: use /c/ prefix in campaign page URL for userId-style vanities

### DIFF
--- a/src/utils/URLHelper.ts
+++ b/src/utils/URLHelper.ts
@@ -319,6 +319,11 @@ export default class URLHelper {
 
   static constructCampaignPageURL(user: UserIdOrVanityParam) {
     if (user.vanity) {
+      // u{digits} vanity means no custom vanity — it's a user ID embedded in the URL path.
+      // /c/ prefix is required to reach the creator page; /{vanity} is just the user profile.
+      if (/^u\d+$/.test(user.vanity)) {
+        return `${SITE_URL}/c/${user.vanity}`;
+      }
       return `${SITE_URL}/${user.vanity}`;
     }
 


### PR DESCRIPTION
Fixes #143

### Problem

Downloading posts from a creator without a custom vanity name fails:

```
patreon-dl https://www.patreon.com/c/u58344051/posts
...
error: PostsFetcher: Error parsing initial data from "https://www.patreon.com/u58344051": Initial data not found - no regex matches
```

`analyzeURL()` extracts `u58344051` as the vanity from the `/c/`-prefixed URL, but `constructCampaignPageURL()` rebuilds the page URL without the `/c/` prefix. For `u{userId}`-style placeholder vanities, the bare `patreon.com/u{userId}` path is the user profile page rather than the creator page, so `PageParser.parseInitialData()` finds none of its expected patterns.

### Fix

In `constructCampaignPageURL()`, keep the `/c/` prefix when the vanity matches the `u{digits}` pattern Patreon uses for creators who never set a custom vanity.

### Verification

Ran the failing command against the patched build:

```
info: PostsFetcher: Fetch posts
info: PostsFetcher: Fetched posts: 20 / 199
info: PostDownloader: Save campaign info #7110673
```

Campaign ID resolves and posts fetch and download normally. Creators with regular custom vanities are unaffected (`/^u\d+$/` does not match them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
