### PR TITLE
fix: patreon added vanity prefixes to post paths

### DIFF
--- a/src/utils/URLHelper.ts
+++ b/src/utils/URLHelper.ts
@@ -17,8 +17,8 @@ const PRODUCT_URL_REGEX = /https:\/\/(?:www\.)?patreon\.com\/([^/]+?)\/shop\/(([
 const POSTS_BY_USER_URL_REGEX = /https:\/\/(?:www\.)?patreon\.com\/([^/]+?)\/posts$/;
 const POSTS_BY_USER_URL_REGEX_2 = /https:\/\/(?:www\.)?patreon\.com\/(?:c|cw)\/([^/]+?)\/posts$/;
 const COLLECTION_URL_REGEX = /https:\/\/(?:www\.)?patreon\.com\/collection\/(\d+)$/;
-const POST_URL_REGEX = /https:\/\/(?:www\.)?patreon\.com\/posts\/(([^/]+)-(\d+))$/;
-const POST_URL_REGEX_2 = /https:\/\/(?:www\.)?patreon\.com\/posts\/(\d+)$/; // No slug
+const POST_URL_REGEX = /https:\/\/(?:www\.)?patreon\.com\/(?:\w+\/)?posts\/(([^/]+)-(\d+))$/;
+const POST_URL_REGEX_2 = /https:\/\/(?:www\.)?patreon\.com\/(?:\w+\/)?posts\/(\d+)$/; // No slug
 const SHOP_URL_REGEX = /https:\/\/(?:www\.)?patreon\.com\/([^/]+?)\/shop$/;
 const SHOP_URL_REGEX_2 = /https:\/\/(?:www\.)?patreon\.com\/(?:c|cw)\/([^/]+?)\/shop$/;
 


### PR DESCRIPTION
I noticed that Patreon URLs have changed to the format `https://www.patreon.com/{creator}/posts/{slug}-{id}` which the regexes don't expect, so doing this seems to address it. Might need to change other regexes, but I'm not confident about which ones need what.

Possibly addresses #145, too.

I don't need credit or anything, but I figured this would be easier for you. Had to fill out all the git things to do this and would prefer anonymity, heh.